### PR TITLE
feat: 採用情報ページを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
                 <li><a href="Ohenro/index.html">お遍路</a></li>
                 <li><a href="Tokaido/index.html">東海道ウォーク</a></li>
                 <li><a href="#company">会社概要</a></li>
-                <li><a href="#recruit">採用情報</a></li>
+                <li><a href="recruit.html">採用情報</a></li>
                 <li><a href="#contact">お問い合わせ</a></li>
             </ul>
             <!-- ハンバーガーメニューボタン（モバイル用） -->

--- a/recruit.css
+++ b/recruit.css
@@ -1,0 +1,1251 @@
+/* 採用情報ページ専用CSS - 堂島フロント企画 */
+
+/* リセット・基本設定 */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Noto Serif JP', serif;
+    line-height: 1.6;
+    background: linear-gradient(180deg, #e8e8e8 0%, #f5f5f5 30%, #ffffff 70%, #e8e8e8 100%);
+    color: #2a2a2a;
+    overflow-x: hidden;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+/* ヘッダー */
+header {
+    background: linear-gradient(135deg, #2a2a2a 0%, #1a1a1a 100%);
+    padding: 20px 0;
+    box-shadow: 0 4px 20px rgba(212, 175, 55, 0.4);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    border-bottom: 3px solid #d4af37;
+}
+
+.header-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.logo h1 {
+    font-size: 2rem;
+    color: #d4af37;
+    font-weight: 700;
+    margin-bottom: 5px;
+}
+
+.logo span {
+    font-size: 1rem;
+    color: #b8860b;
+    display: block;
+}
+
+nav {
+    display: flex;
+    gap: 30px;
+}
+
+nav a {
+    text-decoration: none;
+    color: #f8f8f8;
+    font-size: 1rem;
+    font-weight: 600;
+    padding: 10px 15px;
+    border-radius: 5px;
+    transition: all 0.3s ease;
+    position: relative;
+}
+
+nav a:hover {
+    color: #d4af37;
+    background: rgba(212, 175, 55, 0.1);
+    transform: translateY(-2px);
+}
+
+nav a::after {
+    content: '';
+    position: absolute;
+    bottom: 5px;
+    left: 50%;
+    width: 0;
+    height: 2px;
+    background: #d4af37;
+    transition: all 0.3s ease;
+    transform: translateX(-50%);
+}
+
+nav a:hover::after {
+    width: 80%;
+}
+
+/* ヒーローセクション */
+.hero {
+    background: #f8f9fa;
+    padding: 80px 0;
+    text-align: center;
+    color: #495057;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: radial-gradient(circle at center, rgba(212, 175, 55, 0.1) 0%, transparent 70%);
+}
+
+.hero-content {
+    position: relative;
+    z-index: 2;
+}
+
+.hero h2 {
+    font-size: 2.4rem;
+    font-weight: 600;
+    color: #495057;
+    margin-bottom: 20px;
+    line-height: 1.3;
+}
+
+.hero p {
+    font-size: 1.1rem;
+    color: #6c757d;
+    max-width: 600px;
+    margin: 0 auto 30px;
+    line-height: 1.6;
+}
+
+.hero-highlights {
+    display: flex;
+    justify-content: center;
+    gap: 40px;
+    flex-wrap: wrap;
+    margin-top: 30px;
+}
+
+.highlight-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #ffffff;
+    padding: 10px 18px;
+    border-radius: 6px;
+    border: 1px solid #dee2e6;
+    color: #495057;
+    font-weight: 500;
+    font-size: 0.9rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+
+
+/* 募集職種セクション */
+.positions {
+    padding: 60px 0;
+    background: #ffffff;
+}
+
+
+.positions h2 {
+    text-align: center;
+    font-size: 2rem;
+    color: #495057;
+    margin-bottom: 50px;
+    font-weight: 600;
+}
+
+.positions-subtitle {
+    text-align: center;
+    font-size: 1.1rem;
+    color: #666666;
+    margin-bottom: 60px;
+    font-style: italic;
+}
+
+
+.positions-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 40px;
+    margin-top: 50px;
+    max-width: 1000px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.position-card {
+    background: linear-gradient(135deg, #ffffff 0%, #f8f8f8 50%, #ffffff 100%);
+    border: 2px solid #e0e0e0;
+    border-radius: 20px;
+    padding: 45px 35px;
+    text-align: center;
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+    cursor: pointer;
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1), 0 4px 15px rgba(212, 175, 55, 0.15);
+    min-height: 280px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.position-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(212, 175, 55, 0.1), transparent);
+    transition: left 0.5s ease;
+}
+
+.position-card:hover::before {
+    left: 100%;
+}
+
+.position-card:hover {
+    transform: translateY(-12px) scale(1.02);
+    border-color: #d4af37;
+    box-shadow: 0 25px 50px rgba(212, 175, 55, 0.25), 
+                0 10px 20px rgba(0, 0, 0, 0.4);
+}
+
+
+.position-card h3 {
+    font-size: 1.5rem;
+    color: #d4af37;
+    margin-bottom: 15px;
+    font-weight: 600;
+}
+
+.position-card p {
+    color: #555555;
+    margin-bottom: 20px;
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.salary {
+    background: linear-gradient(135deg, #b8860b, #d4af37);
+    color: #000;
+    padding: 10px 20px;
+    border-radius: 25px;
+    font-weight: 600;
+    font-size: 1.1rem;
+    display: inline-block;
+}
+
+/* カードオーバーレイ */
+.card-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(212, 175, 55, 0.9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    border-radius: 15px;
+}
+
+.position-card:hover .card-overlay {
+    opacity: 1;
+}
+
+/* 職種カードグリッド */
+.position-cards-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-bottom: 60px;
+    max-width: 700px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.position-card {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    padding: 25px 20px;
+    text-align: center;
+    transition: all 0.3s ease;
+    cursor: pointer;
+    position: relative;
+    border: 2px solid transparent;
+    min-height: 180px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.position-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 12px 35px rgba(0, 0, 0, 0.12);
+    border-color: #8b7355;
+}
+
+.position-card h3 {
+    font-size: 1.4em;
+    color: #2c3e50;
+    font-weight: 600;
+    margin-bottom: 15px;
+}
+
+.position-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    gap: 10px;
+}
+
+.position-card .position-type {
+    background: #8b7355;
+    color: white;
+    padding: 5px 12px;
+    border-radius: 15px;
+    font-size: 0.8em;
+    font-weight: 500;
+}
+
+.salary-range {
+    background: #f8f9fa;
+    color: #495057;
+    font-size: 1em;
+    font-weight: 600;
+    padding: 5px 12px;
+    border-radius: 15px;
+    border: 1px solid #dee2e6;
+}
+
+.click-hint {
+    background: #8b7355;
+    color: white;
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 0.85em;
+    font-weight: 500;
+    margin-top: auto;
+    transition: all 0.3s ease;
+}
+
+.position-card:hover .click-hint {
+    background: #6d5a43;
+    transform: scale(1.05);
+}
+
+/* 職種詳細セクション */
+.position-details-section {
+    margin-top: 60px;
+    padding-top: 40px;
+    border-top: 2px solid #8b7355;
+}
+
+.detail-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 40px;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.position-details-section h3 {
+    font-size: 2em;
+    color: #2c3e50;
+    margin: 0;
+    font-weight: 600;
+}
+
+.back-to-positions {
+    background: #8b7355;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 25px;
+    font-size: 0.9em;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.back-to-positions:hover {
+    background: #6d5a43;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(139, 115, 85, 0.3);
+}
+
+.position-detail-section {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    padding: 30px;
+    margin-bottom: 35px;
+}
+
+/* コンパクト詳細セクション */
+.detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 20px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #8b7355;
+}
+
+.detail-header h4 {
+    font-size: 1.5em;
+    color: #2c3e50;
+    font-weight: 600;
+    margin: 0;
+}
+
+.header-info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 5px;
+}
+
+.detail-header .position-type {
+    background: #8b7355;
+    color: white;
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-size: 0.8em;
+    font-weight: 500;
+}
+
+.salary-compact {
+    background: #f8f9fa;
+    color: #495057;
+    font-size: 0.9em;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 12px;
+    border: 1px solid #dee2e6;
+}
+
+.detail-grid-compact {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+}
+
+.detail-item-compact {
+    background: #f8f9fa;
+    border-radius: 8px;
+    padding: 15px;
+}
+
+.detail-item-compact h5 {
+    color: #8b7355;
+    font-size: 1em;
+    margin-bottom: 8px;
+    font-weight: 600;
+}
+
+.detail-item-compact p {
+    color: #555;
+    line-height: 1.5;
+    margin: 0;
+    font-size: 0.9em;
+}
+
+/* 職種詳細カード（レガシー） */
+.position-detail-card {
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    margin-bottom: 40px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+}
+
+.position-header {
+    background: #f8f9fa;
+    padding: 20px 30px;
+    border-bottom: 1px solid #dee2e6;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.position-header h3 {
+    font-size: 1.3rem;
+    color: #495057;
+    margin: 0;
+    font-weight: 600;
+}
+
+.salary-info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+}
+
+.hourly-rate {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #495057;
+}
+
+.monthly-estimate {
+    font-size: 0.85rem;
+    color: #6c757d;
+}
+
+.position-content {
+    padding: 30px;
+}
+
+.position-description {
+    margin-bottom: 30px;
+}
+
+.position-description p {
+    color: #6c757d;
+    line-height: 1.6;
+    margin: 0;
+}
+
+.details-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 30px;
+}
+
+.duties, .requirements {
+    background: #f8f9fa;
+    padding: 20px;
+    border-radius: 6px;
+    border: 1px solid #dee2e6;
+}
+
+.duties h4, .requirements h4 {
+    font-size: 1rem;
+    color: #495057;
+    margin: 0 0 15px 0;
+    font-weight: 600;
+    border-bottom: 1px solid #dee2e6;
+    padding-bottom: 8px;
+}
+
+.duties ul, .requirements ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.duties li, .requirements li {
+    padding: 6px 0;
+    color: #6c757d;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    position: relative;
+    padding-left: 16px;
+}
+
+.duties li::before, .requirements li::before {
+    content: '•';
+    color: #adb5bd;
+    position: absolute;
+    left: 0;
+    top: 6px;
+}
+
+
+
+/* 選考順序セクション */
+.selection-process {
+    padding: 60px 0;
+    background: #f8f9fa;
+    border-top: 1px solid #dee2e6;
+}
+
+
+.selection-process h2 {
+    text-align: center;
+    font-size: 2rem;
+    color: #495057;
+    margin-bottom: 20px;
+    font-weight: 600;
+}
+
+
+.process-subtitle {
+    text-align: center;
+    font-size: 1rem;
+    color: #6c757d;
+    margin-bottom: 40px;
+    font-weight: 400;
+}
+
+.process-timeline {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 20px;
+    margin-bottom: 60px;
+    flex-wrap: wrap;
+}
+
+.process-step {
+    flex: 1;
+    max-width: 300px;
+    min-width: 280px;
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    padding: 30px 20px;
+    text-align: center;
+    position: relative;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+
+.step-number {
+    position: absolute;
+    top: -15px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #495057;
+    color: #ffffff;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+
+.process-step h3 {
+    color: #495057;
+    font-size: 1.1rem;
+    margin-bottom: 15px;
+    font-weight: 600;
+}
+
+.step-description {
+    color: #6c757d;
+    line-height: 1.5;
+    margin-bottom: 15px;
+    font-size: 0.9rem;
+}
+
+.step-time {
+    background: #e9ecef;
+    color: #495057;
+    padding: 6px 12px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    display: inline-block;
+}
+
+.process-arrow {
+    font-size: 1.5rem;
+    color: #adb5bd;
+    align-self: center;
+    font-weight: normal;
+}
+
+
+
+
+
+.highlight-box h4 {
+    color: #2a2a2a;
+    font-size: 1.2rem;
+    margin-bottom: 10px;
+    font-weight: 600;
+}
+
+.highlight-box p {
+    color: #666666;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.process-cta {
+    text-align: center;
+    background: linear-gradient(135deg, rgba(212, 175, 55, 0.08), rgba(255, 215, 0, 0.08));
+    border: 2px solid rgba(212, 175, 55, 0.2);
+    border-radius: 20px;
+    padding: 40px;
+    margin-top: 40px;
+}
+
+.process-cta p {
+    font-size: 1.2rem;
+    color: #2a2a2a;
+    margin-bottom: 25px;
+    font-weight: 500;
+}
+
+.cta-button {
+    background: linear-gradient(135deg, #d4af37, #b8860b);
+    color: #000;
+    border: none;
+    padding: 15px 40px;
+    font-size: 1.1rem;
+    font-weight: 600;
+    border-radius: 30px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-family: inherit;
+}
+
+.cta-button:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 12px 30px rgba(212, 175, 55, 0.4);
+    background: linear-gradient(135deg, #b8860b, #d4af37);
+}
+
+/* 応募フォームセクション */
+.application-form {
+    padding: 100px 0;
+    background: linear-gradient(
+        180deg, 
+        #f8f8f8 0%, 
+        #ffffff 30%, 
+        #f0f0f0 70%,
+        #e8e8e8 100%
+    );
+    position: relative;
+}
+
+.application-form::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: radial-gradient(circle at 80% 20%, rgba(212, 175, 55, 0.06) 0%, transparent 50%);
+    pointer-events: none;
+}
+
+.application-form h2 {
+    text-align: center;
+    font-size: 2.5rem;
+    color: #d4af37;
+    margin-bottom: 60px;
+    position: relative;
+}
+
+.application-form h2::after {
+    content: '';
+    position: absolute;
+    bottom: -15px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100px;
+    height: 3px;
+    background: linear-gradient(90deg, #b8860b, #d4af37, #b8860b);
+}
+
+#recruitForm {
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    padding: 40px;
+    max-width: 800px;
+    margin: 0 auto;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 30px;
+    margin-bottom: 30px;
+}
+
+.form-group {
+    margin-bottom: 25px;
+}
+
+.form-group label {
+    display: block;
+    color: #d4af37;
+    font-weight: 600;
+    margin-bottom: 8px;
+    font-size: 1rem;
+}
+
+.required {
+    color: #ff6b6b;
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+    width: 100%;
+    padding: 12px 15px;
+    background: #ffffff;
+    border: 2px solid #d0d0d0;
+    border-radius: 8px;
+    color: #2a2a2a;
+    font-family: inherit;
+    font-size: 1rem;
+    transition: all 0.3s ease;
+}
+
+.form-group input:focus,
+.form-group textarea:focus,
+.form-group select:focus {
+    outline: none;
+    border-color: #d4af37;
+    box-shadow: 0 0 10px rgba(212, 175, 55, 0.3);
+}
+
+.checkbox-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 15px;
+}
+
+.checkbox-item {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 10px;
+    border-radius: 8px;
+    transition: all 0.3s ease;
+}
+
+.checkbox-item:hover {
+    background: rgba(212, 175, 55, 0.1);
+}
+
+.checkbox-item input[type="checkbox"] {
+    width: auto;
+    margin-right: 10px;
+    accent-color: #d4af37;
+    transform: scale(1.2);
+}
+
+.privacy-policy {
+    border-top: 2px solid #333;
+    padding-top: 20px;
+}
+
+.form-submit {
+    text-align: center;
+    margin-top: 30px;
+}
+
+.form-submit button {
+    background: linear-gradient(135deg, #d4af37, #b8860b);
+    color: #000;
+    border: none;
+    padding: 15px 50px;
+    font-size: 1.2rem;
+    font-weight: 600;
+    border-radius: 50px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-family: inherit;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.form-submit button:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 30px rgba(212, 175, 55, 0.4);
+    background: linear-gradient(135deg, #b8860b, #d4af37);
+}
+
+/* フッター */
+footer {
+    background: #495057;
+    padding: 40px 0 20px;
+    border-top: 1px solid #dee2e6;
+}
+
+.footer-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
+}
+
+.company-info h3 {
+    color: #d4af37;
+    font-size: 1.5rem;
+    margin-bottom: 10px;
+}
+
+.company-info p {
+    color: #cccccc;
+    font-size: 1rem;
+}
+
+.footer-links {
+    display: flex;
+    gap: 30px;
+}
+
+.footer-links a {
+    color: #cccccc;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.footer-links a:hover {
+    color: #d4af37;
+}
+
+.copyright {
+    border-top: 1px solid #333;
+    padding-top: 20px;
+    text-align: center;
+}
+
+.copyright p {
+    color: #888;
+    font-size: 0.9rem;
+}
+
+/* レスポンシブデザイン */
+@media (max-width: 1024px) {
+    .hero h2 {
+        font-size: 2.8rem;
+    }
+    
+    .hero p {
+        font-size: 1.2rem;
+    }
+    
+    .positions-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 30px;
+        max-width: 800px;
+    }
+    
+}
+
+/* レスポンシブデザイン - 新レイアウト対応 */
+@media (max-width: 768px) {
+    .position-cards-grid {
+        grid-template-columns: 1fr;
+        gap: 15px;
+        max-width: 350px;
+    }
+    
+    .position-card {
+        min-height: 160px;
+        padding: 20px 15px;
+    }
+    
+    .position-card h3 {
+        font-size: 1.3em;
+        margin-bottom: 12px;
+    }
+    
+    .position-info {
+        flex-direction: column;
+        gap: 8px;
+        margin-bottom: 15px;
+    }
+    
+    .click-hint {
+        padding: 6px 14px;
+        font-size: 0.8em;
+    }
+    
+    .detail-grid-compact {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+    
+    .position-detail-section {
+        padding: 20px 15px;
+    }
+    
+    .detail-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+    
+    .detail-header h4 {
+        font-size: 1.3em;
+    }
+    
+    .header-info {
+        align-items: flex-start;
+        gap: 8px;
+    }
+    
+    .detail-item-compact {
+        padding: 12px;
+    }
+    
+    .detail-section-header {
+        flex-direction: column;
+        align-items: center;
+        gap: 15px;
+    }
+    
+    .back-to-positions {
+        padding: 8px 16px;
+        font-size: 0.85em;
+    }
+}
+
+@media (max-width: 768px) {
+    .header-container {
+        flex-direction: column;
+        gap: 20px;
+    }
+    
+    nav {
+        gap: 15px;
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+    
+    .hero {
+        padding: 80px 0;
+    }
+    
+    .hero h2 {
+        font-size: 2.2rem;
+    }
+    
+    .hero p {
+        font-size: 1.1rem;
+    }
+
+    .hero-highlights {
+        gap: 20px;
+        margin-top: 25px;
+    }
+
+    .highlight-item {
+        font-size: 0.9rem;
+        padding: 10px 16px;
+    }
+    
+    .positions,
+    .selection-process,
+    .application-form {
+        padding: 60px 0;
+    }
+    
+    .positions h2,
+    .selection-process h2,
+    .application-form h2 {
+        font-size: 2rem;
+    }
+
+    .process-timeline {
+        flex-direction: column;
+        align-items: center;
+        gap: 30px;
+    }
+
+    .process-step {
+        max-width: none;
+        min-width: auto;
+        width: 100%;
+    }
+
+    .process-arrow {
+        transform: rotate(90deg);
+        font-size: 1.5rem;
+    }
+
+
+    .process-cta {
+        padding: 30px 20px;
+    }
+
+    .process-cta p {
+        font-size: 1.1rem;
+    }
+    
+    .positions-subtitle {
+        font-size: 1rem;
+        margin-bottom: 40px;
+    }
+    
+    .positions-grid {
+        grid-template-columns: 1fr;
+        gap: 25px;
+        max-width: 500px;
+    }
+    
+    .position-card {
+        padding: 30px 20px;
+    }
+    
+    .tap-hint {
+        font-size: 1rem;
+    }
+    
+    .modal-content {
+        width: 95%;
+        margin: 10% auto;
+        max-height: 85vh;
+    }
+    
+    .modal-header {
+        padding: 15px 20px;
+    }
+    
+    .modal-header h3 {
+        font-size: 1.3rem;
+    }
+    
+    .modal-body {
+        padding: 20px;
+    }
+    
+    .modal-footer {
+        padding: 15px 20px;
+    }
+    
+    .position-detail h4 {
+        font-size: 1.1rem;
+    }
+    
+    .salary-highlight {
+        font-size: 1.1rem;
+        padding: 12px;
+    }
+    
+    
+    #recruitForm {
+        padding: 30px 20px;
+    }
+    
+    .form-grid {
+        grid-template-columns: 1fr;
+        gap: 20px;
+    }
+    
+    .checkbox-group {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+    
+    .footer-content {
+        flex-direction: column;
+        gap: 20px;
+        text-align: center;
+    }
+    
+    .footer-links {
+        gap: 15px;
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+}
+
+@media (max-width: 480px) {
+    .container {
+        padding: 0 15px;
+    }
+    
+    .hero h2 {
+        font-size: 1.8rem;
+    }
+    
+    .hero p {
+        font-size: 1rem;
+    }
+
+    .hero-highlights {
+        gap: 15px;
+        margin-top: 20px;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .highlight-item {
+        font-size: 0.85rem;
+        padding: 8px 14px;
+    }
+    
+    .positions h2,
+    .selection-process h2,
+    .application-form h2 {
+        font-size: 1.8rem;
+    }
+
+    .process-cta {
+        padding: 25px 15px;
+    }
+
+    .process-cta p {
+        font-size: 1rem;
+    }
+
+    .cta-button {
+        padding: 12px 30px;
+        font-size: 1rem;
+    }
+
+    .process-step {
+        padding: 30px 20px;
+    }
+
+    .step-icon {
+        font-size: 2.5rem;
+    }
+    
+    .position-card {
+        padding: 25px 15px;
+    }
+    
+    .position-card h3 {
+        font-size: 1.3rem;
+    }
+    
+    
+    #recruitForm {
+        padding: 20px 15px;
+    }
+    
+    .qualifications {
+        flex-direction: column;
+        gap: 10px;
+    }
+    
+    .qualification-tag {
+        text-align: center;
+    }
+}

--- a/recruit.html
+++ b/recruit.html
@@ -1,0 +1,396 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>採用情報 - 堂島フロント企画</title>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="recruit.css">
+</head>
+<body>
+    <!-- ヘッダー -->
+    <header>
+        <div class="header-container">
+            <div class="logo">
+                <h1>堂島フロント企画</h1>
+                <span>採用情報</span>
+            </div>
+            <nav>
+                <a href="index.html">ホーム</a>
+                <a href="Ohenro/index.html">お遍路事業</a>
+                <a href="Tokaido/index.html">東海道ウォーク事業</a>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <!-- ヒーローセクション -->
+        <section class="hero">
+            <div class="hero-content">
+                <h2>一緒に巡礼の旅を<br>サポートしませんか</h2>
+                <p>堂島フロント企画では、お遍路・東海道ウォークツアーの<br>添乗員・アシスタント・ガイドを募集しています</p>
+                <div class="hero-highlights">
+                    <div class="highlight-item">
+                        <span>初心者歓迎</span>
+                    </div>
+                    <div class="highlight-item">
+                        <span>交通費全額支給</span>
+                    </div>
+                    <div class="highlight-item">
+                        <span>経験により昇給</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 募集職種セクション -->
+        <section class="positions">
+            <div class="container">
+                <h2>募集職種</h2>
+                <p class="section-intro">あなたの経験を活かせるポジションを見つけてください</p>
+                
+                <!-- 職種カードグリッド -->
+                <div class="position-cards-grid">
+                    <div class="position-card" onclick="scrollToDetails('tenjouin')">
+                        <h3>添乗員</h3>
+                        <div class="position-info">
+                            <span class="position-type">正社員・パート</span>
+                            <span class="salary-range">時給1,100円～</span>
+                        </div>
+                        <div class="click-hint">詳細を見る ▼</div>
+                    </div>
+                    
+                    <div class="position-card" onclick="scrollToDetails('assistant')">
+                        <h3>アシスタント</h3>
+                        <div class="position-info">
+                            <span class="position-type">パートタイム</span>
+                            <span class="salary-range">時給1,100円～</span>
+                        </div>
+                        <div class="click-hint">詳細を見る ▼</div>
+                    </div>
+                    
+                    <div class="position-card" onclick="scrollToDetails('sendatsu')">
+                        <h3>先達</h3>
+                        <div class="position-info">
+                            <span class="position-type">業務委託</span>
+                            <span class="salary-range">日当10,000円～</span>
+                        </div>
+                        <div class="click-hint">詳細を見る ▼</div>
+                    </div>
+                    
+                    <div class="position-card" onclick="scrollToDetails('walkleader')">
+                        <h3>街道ウォークリーダー</h3>
+                        <div class="position-info">
+                            <span class="position-type">業務委託</span>
+                            <span class="salary-range">日当13,000円～</span>
+                        </div>
+                        <div class="click-hint">詳細を見る ▼</div>
+                    </div>
+                </div>
+
+                <!-- 職種詳細セクション -->
+                <div class="position-details-section" style="display: none;">
+                    <div class="detail-section-header">
+                        <h3 id="detail-section-title">職種詳細</h3>
+                        <button class="back-to-positions" onclick="hideAllDetails()">← 職種一覧に戻る</button>
+                    </div>
+                    
+                    <!-- 添乗員詳細 -->
+                    <div id="tenjouin-details" class="position-detail-section" style="display: none;">
+                        <div class="detail-header">
+                            <h4>添乗員</h4>
+                            <div class="header-info">
+                                <span class="position-type">正社員・パート</span>
+                                <span class="salary-compact">時給1,100円～（月収例：88,000円～）</span>
+                            </div>
+                        </div>
+
+                        <div class="detail-grid-compact">
+                            <div class="detail-item-compact">
+                                <h5>仕事内容</h5>
+                                <p>ツアー参加者の出欠確認、バス乗降時の安全管理、宿泊施設での手続き、緊急時の対応</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>求める人物</h5>
+                                <p>責任感が強く細かい気配りができる方、緊急時に冷静な判断ができる方、接客経験者歓迎</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>勤務条件</h5>
+                                <p>四国各地・東海道沿線、ツアー日程により変動、宿泊を伴う場合あり</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>待遇</h5>
+                                <p>交通費全額支給、宿泊費会社負担、食事手当支給、各種保険完備</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- アシスタント詳細 -->
+                    <div id="assistant-details" class="position-detail-section" style="display: none;">
+                        <div class="detail-header">
+                            <h4>アシスタント</h4>
+                            <div class="header-info">
+                                <span class="position-type">パートタイム</span>
+                                <span class="salary-compact">時給1,100円～（月収例：66,000円～）</span>
+                            </div>
+                        </div>
+
+                        <div class="detail-grid-compact">
+                            <div class="detail-item-compact">
+                                <h5>仕事内容</h5>
+                                <p>添乗員の業務サポート、参加者の荷物管理補助、バス内での安全確認、高齢者サポート</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>求める人物</h5>
+                                <p>人とのコミュニケーションが好きな方、体力に自信のある方、チームワークを大切にできる方</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>勤務条件</h5>
+                                <p>四国各地・東海道沿線、ツアー日程により変動、パートタイム勤務</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>待遇</h5>
+                                <p>交通費全額支給、研修制度充実、正社員登用制度あり、各種手当支給</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 先達詳細 -->
+                    <div id="sendatsu-details" class="position-detail-section" style="display: none;">
+                        <div class="detail-header">
+                            <h4>先達</h4>
+                            <div class="header-info">
+                                <span class="position-type">業務委託</span>
+                                <span class="salary-compact">日当10,000円～（月収例：120,000円～）</span>
+                            </div>
+                        </div>
+
+                        <div class="detail-grid-compact">
+                            <div class="detail-item-compact">
+                                <h5>仕事内容</h5>
+                                <p>各霊場での案内・解説、朱印帳への朱印押印代行、巡礼作法の指導、参加者の巡礼サポート</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>求める人物</h5>
+                                <p>四国八十八ヶ所霊場会認定先達資格必須、巡礼経験豊富、仏教や四国遍路に関する深い知識</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>勤務条件</h5>
+                                <p>四国八十八ヶ所霊場、ツアー日程により変動、業務委託契約</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>待遇</h5>
+                                <p>交通費・宿泊費全額支給、高額日当（経験により優遇）、専門知識を活かせる環境</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 街道ウォークリーダー詳細 -->
+                    <div id="walkleader-details" class="position-detail-section" style="display: none;">
+                        <div class="detail-header">
+                            <h4>街道ウォークリーダー</h4>
+                            <div class="header-info">
+                                <span class="position-type">業務委託</span>
+                                <span class="salary-compact">日当13,000円～（月収例：90,000円～）</span>
+                            </div>
+                        </div>
+
+                        <div class="detail-grid-compact">
+                            <div class="detail-item-compact">
+                                <h5>仕事内容</h5>
+                                <p>ウォーキングツアーの先導、歴史的建造物・史跡の解説、参加者の体調管理・ペース調整</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>求める人物</h5>
+                                <p>ウォーキング・ハイキング経験豊富、歴史や文化に興味、体力に自信があり長距離歩行が可能</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>勤務条件</h5>
+                                <p>東海道五十三次沿線、ツアー日程により変動、業務委託契約</p>
+                            </div>
+                            <div class="detail-item-compact">
+                                <h5>待遇</h5>
+                                <p>交通費・宿泊費全額支給、高額日当（最高レベル）、歴史知識を活かせる専門職</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+
+        <!-- 選考順序セクション -->
+        <section class="selection-process">
+            <div class="container">
+                <h2>選考の流れ</h2>
+                <p class="process-subtitle">簡単3ステップで採用決定！最短即日から働けます</p>
+                
+                <div class="process-timeline">
+                    <div class="process-step">
+                        <div class="step-number">1</div>
+                        <div class="step-content">
+                            <h3>応募フォーム入力</h3>
+                            <p class="step-description">
+                                下記の応募フォームから必要事項をご入力ください。
+                                入力は約3分で完了します。
+                            </p>
+                            <div class="step-time">所要時間：3分</div>
+                        </div>
+                    </div>
+
+                    <div class="process-arrow">→</div>
+
+                    <div class="process-step">
+                        <div class="step-number">2</div>
+                        <div class="step-content">
+                            <h3>簡単面接</h3>
+                            <p class="step-description">
+                                お電話またはオンラインでの簡単な面接を行います。
+                                お仕事内容の説明と簡単な質疑応答です。
+                            </p>
+                            <div class="step-time">所要時間：10分</div>
+                        </div>
+                    </div>
+
+                    <div class="process-arrow">→</div>
+
+                    <div class="process-step">
+                        <div class="step-number">3</div>
+                        <div class="step-content">
+                            <h3>合否連絡・勤務開始</h3>
+                            <p class="step-description">
+                                面接後、原則24時間以内に合否をご連絡いたします。
+                                採用となった場合、最短即日から勤務可能です。
+                            </p>
+                            <div class="step-time">連絡まで：24時間以内</div>
+                        </div>
+                    </div>
+                </div>
+
+
+                <div class="process-cta">
+                    <p>今すぐ応募して、新しい働き方を始めませんか？</p>
+                    <button class="cta-button" onclick="scrollToForm()">応募フォームへ進む</button>
+                </div>
+            </div>
+        </section>
+
+        <!-- 応募フォームセクション -->
+        <section class="application-form">
+            <div class="container">
+                <h2>応募フォーム</h2>
+                <form id="recruitForm">
+                    <div class="form-grid">
+                        <div class="form-group">
+                            <label for="name">お名前 <span class="required">*</span></label>
+                            <input type="text" id="name" name="name" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="kana">フリガナ <span class="required">*</span></label>
+                            <input type="text" id="kana" name="kana" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="email">メールアドレス <span class="required">*</span></label>
+                            <input type="email" id="email" name="email" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="phone">電話番号 <span class="required">*</span></label>
+                            <input type="tel" id="phone" name="phone" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="age">年齢</label>
+                            <input type="number" id="age" name="age" min="18" max="100">
+                        </div>
+                        <div class="form-group">
+                            <label for="address">住所</label>
+                            <input type="text" id="address" name="address">
+                        </div>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="position">希望職種 <span class="required">*</span></label>
+                        <div class="checkbox-group">
+                            <label class="checkbox-item">
+                                <input type="checkbox" name="position" value="添乗員">
+                                <span>添乗員</span>
+                            </label>
+                            <label class="checkbox-item">
+                                <input type="checkbox" name="position" value="アシスタント">
+                                <span>アシスタント</span>
+                            </label>
+                            <label class="checkbox-item">
+                                <input type="checkbox" name="position" value="先達">
+                                <span>先達</span>
+                            </label>
+                            <label class="checkbox-item">
+                                <input type="checkbox" name="position" value="街道ウォークリーダー">
+                                <span>街道ウォークリーダー</span>
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="experience">関連経験・資格</label>
+                        <textarea id="experience" name="experience" rows="4" placeholder="巡礼経験、ガイド経験、保有資格などをご記入ください"></textarea>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="motivation">応募理由・自己PR</label>
+                        <textarea id="motivation" name="motivation" rows="4" placeholder="応募理由や自己PRをご記入ください"></textarea>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="availability">勤務可能時期</label>
+                        <select id="availability" name="availability">
+                            <option value="">選択してください</option>
+                            <option value="即日">即日から</option>
+                            <option value="1週間以内">1週間以内</option>
+                            <option value="2週間以内">2週間以内</option>
+                            <option value="1ヶ月以内">1ヶ月以内</option>
+                            <option value="相談">要相談</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="message">その他・ご質問</label>
+                        <textarea id="message" name="message" rows="3" placeholder="ご質問やご要望があればご記入ください"></textarea>
+                    </div>
+
+                    <div class="form-group privacy-policy">
+                        <label class="checkbox-item">
+                            <input type="checkbox" id="privacy" name="privacy" required>
+                            <span>個人情報の取扱いに同意します <span class="required">*</span></span>
+                        </label>
+                    </div>
+
+                    <div class="form-submit">
+                        <button type="submit">応募する</button>
+                    </div>
+                </form>
+            </div>
+        </section>
+    </main>
+
+    <!-- フッター -->
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="company-info">
+                    <h3>堂島フロント企画</h3>
+                    <p>お遍路・東海道ウォークツアーの専門企画会社</p>
+                </div>
+                <div class="footer-links">
+                    <a href="index.html">ホーム</a>
+                    <a href="Ohenro/index.html">お遍路事業</a>
+                    <a href="Tokaido/index.html">東海道ウォーク事業</a>
+                </div>
+            </div>
+            <div class="copyright">
+                <p>&copy; 2024 堂島フロント企画. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="recruit.js"></script>
+</body>
+</html>

--- a/recruit.js
+++ b/recruit.js
@@ -1,0 +1,323 @@
+// 採用情報ページ専用JavaScript - 堂島フロント企画
+
+document.addEventListener('DOMContentLoaded', function() {
+    // DOM要素の取得とキャッシュ
+    const form = document.getElementById('recruitForm');
+    const nameInput = document.getElementById('name');
+    const kanaInput = document.getElementById('kana');
+    const emailInput = document.getElementById('email');
+    const phoneInput = document.getElementById('phone');
+    const positionCheckboxes = document.querySelectorAll('input[name="position"]');
+    const privacyCheckbox = document.getElementById('privacy');
+
+    // 初期化
+    initFormValidation();
+    initFormAnimations();
+    initFormSubmission();
+
+    // フォームバリデーション
+    function initFormValidation() {
+        // リアルタイムバリデーション
+        nameInput.addEventListener('blur', validateName);
+        kanaInput.addEventListener('blur', validateKana);
+        emailInput.addEventListener('blur', validateEmail);
+        phoneInput.addEventListener('blur', validatePhone);
+        
+        // 職種選択のバリデーション
+        positionCheckboxes.forEach(checkbox => {
+            checkbox.addEventListener('change', validatePositions);
+        });
+        
+        // プライバシーポリシー同意のバリデーション
+        privacyCheckbox.addEventListener('change', validatePrivacy);
+    }
+
+    // フォームアニメーション
+    function initFormAnimations() {
+        // フォーカス時のアニメーション
+        const formInputs = form.querySelectorAll('input, textarea, select');
+        
+        formInputs.forEach(input => {
+            input.addEventListener('focus', function() {
+                this.parentElement.classList.add('focused');
+            });
+            
+            input.addEventListener('blur', function() {
+                if (!this.value.trim()) {
+                    this.parentElement.classList.remove('focused');
+                }
+            });
+        });
+    }
+
+    // フォーム送信処理
+    function initFormSubmission() {
+        form.addEventListener('submit', function(e) {
+            e.preventDefault();
+            
+            // 全体バリデーション
+            if (validateForm()) {
+                submitForm();
+            } else {
+                showErrorMessage('入力内容に不備があります。エラー項目を確認してください。');
+            }
+        });
+    }
+
+    // 名前のバリデーション
+    function validateName() {
+        const name = nameInput.value.trim();
+        if (!name) {
+            showFieldError(nameInput, 'お名前を入力してください');
+            return false;
+        } else if (name.length < 2) {
+            showFieldError(nameInput, 'お名前は2文字以上で入力してください');
+            return false;
+        } else {
+            showFieldSuccess(nameInput);
+            return true;
+        }
+    }
+
+    // フリガナのバリデーション
+    function validateKana() {
+        const kana = kanaInput.value.trim();
+        const kanaRegex = /^[\u30A1-\u30FC\u3041-\u3096\s]*$/;
+        
+        if (!kana) {
+            showFieldError(kanaInput, 'フリガナを入力してください');
+            return false;
+        } else if (!kanaRegex.test(kana)) {
+            showFieldError(kanaInput, 'フリガナはひらがな・カタカナで入力してください');
+            return false;
+        } else {
+            showFieldSuccess(kanaInput);
+            return true;
+        }
+    }
+
+    // メールアドレスのバリデーション
+    function validateEmail() {
+        const email = emailInput.value.trim();
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        
+        if (!email) {
+            showFieldError(emailInput, 'メールアドレスを入力してください');
+            return false;
+        } else if (!emailRegex.test(email)) {
+            showFieldError(emailInput, '正しいメールアドレスを入力してください');
+            return false;
+        } else {
+            showFieldSuccess(emailInput);
+            return true;
+        }
+    }
+
+    // 電話番号のバリデーション
+    function validatePhone() {
+        const phone = phoneInput.value.trim();
+        const phoneRegex = /^[\d\-]{10,}$/;
+        
+        if (!phone) {
+            showFieldError(phoneInput, '電話番号を入力してください');
+            return false;
+        } else if (!phoneRegex.test(phone)) {
+            showFieldError(phoneInput, '正しい電話番号を入力してください');
+            return false;
+        } else {
+            showFieldSuccess(phoneInput);
+            return true;
+        }
+    }
+
+    // 職種選択のバリデーション
+    function validatePositions() {
+        const checkedPositions = document.querySelectorAll('input[name="position"]:checked');
+        const errorElement = document.querySelector('.position-error');
+        
+        if (checkedPositions.length === 0) {
+            if (!errorElement) {
+                const error = document.createElement('div');
+                error.className = 'position-error error-message';
+                error.textContent = '希望職種を最低1つ選択してください';
+                document.querySelector('.checkbox-group').parentElement.appendChild(error);
+            }
+            return false;
+        } else {
+            if (errorElement) {
+                errorElement.remove();
+            }
+            return true;
+        }
+    }
+
+    // プライバシーポリシー同意のバリデーション
+    function validatePrivacy() {
+        if (!privacyCheckbox.checked) {
+            showFieldError(privacyCheckbox, '個人情報の取扱いに同意してください');
+            return false;
+        } else {
+            showFieldSuccess(privacyCheckbox);
+            return true;
+        }
+    }
+
+    // 全体バリデーション
+    function validateForm() {
+        const validations = [
+            validateName(),
+            validateKana(),
+            validateEmail(),
+            validatePhone(),
+            validatePositions(),
+            validatePrivacy()
+        ];
+        
+        return validations.every(result => result === true);
+    }
+
+    // フィールドエラー表示
+    function showFieldError(field, message) {
+        clearFieldMessages(field);
+        
+        const errorDiv = document.createElement('div');
+        errorDiv.className = 'error-message';
+        errorDiv.textContent = message;
+        
+        field.parentElement.appendChild(errorDiv);
+        field.classList.add('error');
+    }
+
+    // フィールド成功表示
+    function showFieldSuccess(field) {
+        clearFieldMessages(field);
+        field.classList.add('success');
+    }
+
+    // フィールドメッセージクリア
+    function clearFieldMessages(field) {
+        const existingError = field.parentElement.querySelector('.error-message');
+        if (existingError) {
+            existingError.remove();
+        }
+        field.classList.remove('error', 'success');
+    }
+
+    // エラーメッセージ表示
+    function showErrorMessage(message) {
+        const existingError = form.querySelector('.form-error');
+        if (existingError) {
+            existingError.remove();
+        }
+        
+        const errorDiv = document.createElement('div');
+        errorDiv.className = 'form-error';
+        errorDiv.textContent = message;
+        
+        form.insertBefore(errorDiv, form.firstChild);
+        
+        setTimeout(() => {
+            if (errorDiv.parentElement) {
+                errorDiv.remove();
+            }
+        }, 5000);
+    }
+
+    // フォーム送信
+    function submitForm() {
+        const submitButton = form.querySelector('button[type="submit"]');
+        const originalText = submitButton.textContent;
+        
+        submitButton.disabled = true;
+        submitButton.textContent = '送信中...';
+        
+        // フォームデータの収集
+        const formData = new FormData(form);
+        
+        // 実際の送信処理（サンプル）
+        setTimeout(() => {
+            alert('応募を受け付けました。ありがとうございます。\n担当者より3営業日以内にご連絡いたします。');
+            form.reset();
+            
+            // エラーメッセージをクリア
+            form.querySelectorAll('.error-message').forEach(error => error.remove());
+            form.querySelectorAll('.error, .success').forEach(field => {
+                field.classList.remove('error', 'success');
+            });
+            
+            submitButton.disabled = false;
+            submitButton.textContent = originalText;
+        }, 2000);
+    }
+
+    // フォームまでスクロール
+    window.scrollToForm = function() {
+        const formSection = document.querySelector('.application-form');
+        if (formSection) {
+            formSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    }
+
+    // 職種詳細表示機能
+    window.scrollToDetails = function(positionId) {
+        // 全ての詳細セクションを非表示
+        const allDetails = document.querySelectorAll('.position-detail-section');
+        allDetails.forEach(detail => {
+            detail.style.display = 'none';
+        });
+
+        // 選択された詳細セクションを表示
+        const targetElement = document.getElementById(positionId + '-details');
+        const detailsSection = document.querySelector('.position-details-section');
+        const sectionTitle = document.getElementById('detail-section-title');
+        
+        if (targetElement && detailsSection && sectionTitle) {
+            // 詳細セクション全体を表示
+            detailsSection.style.display = 'block';
+            
+            // 選択された職種の詳細を表示
+            targetElement.style.display = 'block';
+            
+            // タイトルを更新
+            const positionName = targetElement.querySelector('h4').textContent;
+            sectionTitle.textContent = `${positionName} - 詳細情報`;
+
+            // 詳細セクションまでスクロール
+            const elementPosition = detailsSection.getBoundingClientRect().top + window.pageYOffset;
+            const offsetPosition = elementPosition - 80; // 80px上にマージンを取る
+
+            window.scrollTo({
+                top: offsetPosition,
+                behavior: 'smooth'
+            });
+
+            // 一時的にハイライトエフェクトを追加
+            targetElement.style.transition = 'box-shadow 0.3s ease';
+            targetElement.style.boxShadow = '0 8px 35px rgba(139, 115, 85, 0.3)';
+            
+            setTimeout(() => {
+                targetElement.style.boxShadow = '0 4px 20px rgba(0, 0, 0, 0.08)';
+            }, 2000);
+        }
+    }
+
+    // 全詳細を非表示にして職種一覧に戻る
+    window.hideAllDetails = function() {
+        const detailsSection = document.querySelector('.position-details-section');
+        const cardsGrid = document.querySelector('.position-cards-grid');
+        
+        if (detailsSection && cardsGrid) {
+            // 詳細セクションを非表示
+            detailsSection.style.display = 'none';
+            
+            // 職種カードまでスクロール
+            const elementPosition = cardsGrid.getBoundingClientRect().top + window.pageYOffset;
+            const offsetPosition = elementPosition - 100; // 100px上にマージンを取る
+
+            window.scrollTo({
+                top: offsetPosition,
+                behavior: 'smooth'
+            });
+        }
+    }
+});


### PR DESCRIPTION
Webサイトに新しく採用情報ページを導入しました。

- `recruit.html`を作成し、募集職種、選考フロー、応募フォームを掲載
- `recruit.css`を追加し、採用情報ページをスタイリング
- `recruit.js`を実装し、フォームのバリデーションやインタラクティブな動作を追加
- `index.html`のナビゲーションバーを更新し、新しい採用情報ページへのリンクを修正